### PR TITLE
@

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (without leading v), e.g. 0.1.0"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    name: Create GitHub Release (Zenodo archives it)
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUTF8: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Verify workspace versions agree with the tag
+        run: |
+          python scripts/check_versions.py
+          declared=$(python scripts/check_versions.py | awk '/workspace version is/ {print $NF}')
+          if [ "$declared" != "${{ steps.version.outputs.value }}" ]; then
+            echo "Tag/input ${{ steps.version.outputs.value }} != declared $declared" >&2
+            exit 1
+          fi
+      - name: Build release notes from CHANGELOG
+        run: python scripts/extract_changelog.py "${{ steps.version.outputs.value }}" > release_notes.md
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.value }}
+          name: v${{ steps.version.outputs.value }}
+          body_path: release_notes.md

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -1,0 +1,34 @@
+name: Workspace
+
+on:
+  push:
+    paths:
+      - ".github/workflows/workspace.yml"
+      - "CITATION.cff"
+      - "CHANGELOG.md"
+      - "scripts/**"
+      - "**/pyproject.toml"
+  pull_request:
+    paths:
+      - ".github/workflows/workspace.yml"
+      - "CITATION.cff"
+      - "CHANGELOG.md"
+      - "scripts/**"
+      - "**/pyproject.toml"
+
+jobs:
+  versions:
+    name: Workspace version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check versions agree across CITATION.cff and pyproject files
+        run: python scripts/check_versions.py
+      - name: Check CHANGELOG has a section for the current version
+        run: |
+          version=$(python scripts/check_versions.py | awk '/workspace version is/ {print $NF}')
+          python scripts/extract_changelog.py "$version" > /dev/null
+          echo "CHANGELOG has a section for $version"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ PythonSpinDynamics/.mypy_cache/
 PythonSpinDynamics/.ruff_cache/
 PythonSpinDynamics/results/
 PythonSpinDynamics/src/*.egg-info/
+PythonSpinDynamics/*.egg-info/
+PythonSpinDynamics/build/
+PythonSpinDynamics/dist/
+PythonSpinDynamics/site/
 PythonSpinDynamics/**/__pycache__/
 PythonSpinDynamics/**/*.py[cod]
 PythonSpinDynamics/**/*.npz

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,22 @@
+{
+  "title": "MRSpinDynamics",
+  "description": "A research workspace for magnetic-resonance simulation, quadrupolar-parameter analysis, and NQR data curation: a validated Python spin-dynamics package (NMR, NQR, ESR/EPR), an ab initio electric-field-gradient and quadrupolar-coupling workflow, a curated machine-readable NQR spectra database with provenance, and a cross-project layer closing the predict-simulate-validate loop.",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "GPL-3.0-or-later",
+  "creators": [
+    { "name": "Mandal, Soumyajit" }
+  ],
+  "keywords": [
+    "NMR",
+    "NQR",
+    "ESR",
+    "EPR",
+    "spin dynamics",
+    "magnetic resonance",
+    "quadrupolar coupling",
+    "electric field gradient",
+    "DFT",
+    "CPMG"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to the **MRSpinDynamics** workspace are recorded here. The
+repository is released as a single citable unit (see [`CITATION.cff`](CITATION.cff)
+and [`docs/release_process.md`](docs/release_process.md)); one version covers all
+subprojects. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-06-28
+
+First tagged release of the workspace. This consolidates the work tracked in
+[`docs/roadmap.md`](docs/roadmap.md) into one citable snapshot. Subprojects are
+at deliberately different maturity levels (see each subproject's README and the
+roadmap); the shared version marks the state of the workspace as a whole, not a
+uniform stability guarantee.
+
+### PythonSpinDynamics — production-grade simulation package
+
+- NMR workflows: ideal/tuned/untuned/matched-probe CPMG, finite echo trains,
+  inversion recovery, Q/mistuning sweeps, diffusion CPMG, PGSE/PGSTE, WURST,
+  prepolarization, radiation damping, and moving-isochromat motion.
+- Imaging: spin-warp, RARE, slice-selective and true-3D multi-slice imaging in
+  spatially varying `(B0, B1)`; analytic magnet field sources including a
+  single-sided NMR-MOUSE simulation.
+- NQR: spin-1 reduced two-level and spin-3/2 full density-matrix models, powder
+  averaging, weak-B0 spectra, SLSE, and population transfer.
+- ESR/EPR: single-electron spectra, anisotropic g tensors, powder grids, pulsed
+  FID/Hahn echo, hyperfine doublets.
+- Relaxation: shared Liouville helpers, phenomenological models, and an opt-in
+  Redfield/dipolar model with rigid-solid and isotropic-liquid averaging.
+- Analysis: 1D/2D inverse-Laplace for T1, T2, T1-T2, D-T2; coupling and exchange
+  models; q-space pore-imaging inversion and phase retrieval.
+- Optional Numba and JAX isochromat backends. Core runtime depends only on NumPy.
+- Validated against the MATLAB reference; see
+  [`PythonSpinDynamics/docs/python_api/validation.md`](PythonSpinDynamics/docs/python_api/validation.md)
+  and remaining limitations in
+  [`PythonSpinDynamics/docs/python_api/known_gaps.md`](PythonSpinDynamics/docs/python_api/known_gaps.md).
+
+### QuadrupolarDFT — ab initio EFG and quadrupolar coupling
+
+- EFG -> C_Q, eta, and predicted NQR frequencies from first-principles outputs.
+- Harmonic finite-temperature vibrational averaging of the EFG tensor with a
+  Bayer single-libration fit; full three-stage ABINIT DFPT workflow
+  (phonon -> displace -> collect), validated against real `.abo` EFG output.
+
+### NQRDatabase — curated measured spectra
+
+- 184 compounds with measured NQR frequencies, provenance, and citations.
+- SQLite and JSONL exports; a review workflow for OCR-derived Landolt-Bornstein
+  tables; an explorer web app with per-site consistency badges.
+
+### integration (mr_integration) — predict-simulate-validate loop
+
+- Validated C_Q <-> nu_Q conversion bridging the DFT and simulator conventions.
+- Cross-validation that runs DFT-derived parameters through the simulator and
+  checks self-consistency against the curated database.
+- Simulator-driven database self-consistency and Landolt review-queue flagging,
+  surfaced in the NQR explorer.
+
+### Workspace
+
+- Single-version release process, `CITATION.cff`, `.zenodo.json`, and
+  [`docs/release_process.md`](docs/release_process.md) for GitHub-Release-driven
+  Zenodo DOI minting.
+
+[Unreleased]: https://github.com/supertjhok/MRSpinDynamics/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/supertjhok/MRSpinDynamics/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using the metadata below."
+title: "MRSpinDynamics"
+abstract: >-
+  A research workspace for magnetic-resonance simulation, quadrupolar-parameter
+  analysis, and NQR data curation. It bundles a validated Python spin-dynamics
+  package (NMR, NQR, and ESR/EPR), an ab initio electric-field-gradient and
+  quadrupolar-coupling workflow, a curated machine-readable NQR spectra database
+  with provenance, and a cross-project layer that closes the
+  predict-simulate-validate loop between them.
+type: software
+authors:
+  - family-names: Mandal
+    given-names: Soumyajit
+version: 0.1.0
+date-released: 2026-06-28
+license: GPL-3.0-or-later
+repository-code: "https://github.com/supertjhok/MRSpinDynamics"
+url: "https://github.com/supertjhok/MRSpinDynamics"
+keywords:
+  - NMR
+  - NQR
+  - ESR
+  - EPR
+  - spin dynamics
+  - magnetic resonance
+  - quadrupolar coupling
+  - electric field gradient
+  - DFT
+  - CPMG
+# After the first GitHub Release is archived on Zenodo, add the minted DOI here
+# (and a doi: field on the matching entry in CHANGELOG.md / README badge):
+# doi: 10.5281/zenodo.XXXXXXX

--- a/PythonSpinDynamics/pyproject.toml
+++ b/PythonSpinDynamics/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-spin-dynamics"
-version = "0.0.0"
+version = "0.1.0"
 description = "Python workspace for magnetic-resonance spin-dynamics simulations."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/QuadrupolarDFT/pyproject.toml
+++ b/QuadrupolarDFT/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quadrupolar-dft"
-version = "0.0.0"
+version = "0.1.0"
 description = "Ab initio EFG and quadrupolar-coupling workflow helpers."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ repository:
   regimes used by `PythonSpinDynamics`. The LaTeX source is tracked beside the
   PDF.
 
+## Releases and Citation
+
+MRSpinDynamics is released as a single citable unit: the whole repository is
+versioned together, tagged once (`v<version>`), published as one GitHub Release,
+and archived on Zenodo for a citable DOI. The current version and per-component
+release notes are in [`CHANGELOG.md`](CHANGELOG.md); the process is documented in
+[`docs/release_process.md`](docs/release_process.md).
+
+To cite this software, use the metadata in [`CITATION.cff`](CITATION.cff) (GitHub
+renders a "Cite this repository" button from it). Once the first release is
+archived, the Zenodo DOI will be added here and to `CITATION.cff`.
+
 ## License
 
 Copyright (C) 2026 Soumyajit Mandal

--- a/docs/publishing_plan.md
+++ b/docs/publishing_plan.md
@@ -1,6 +1,16 @@
-# PythonSpinDynamics Publishing Plan
+# PythonSpinDynamics Publishing Plan (deferred / future option)
 
 _Last updated: 2026-06-28_
+
+> **Status: not the current release model.** MRSpinDynamics is released as a
+> single citable workspace unit (one repo version, one GitHub Release, one Zenodo
+> DOI) — see [`release_process.md`](release_process.md). This document describes a
+> **possible future** direction: publishing `PythonSpinDynamics` as an
+> independently versioned PyPI distribution. It is kept for reference and should
+> only be revisited if there is concrete demand for `pip install`-able subpackages.
+> Note the dependency ordering it would require: `python-spin-dynamics` would have
+> to be on PyPI before `quadrupolar-dft`, and both before `mr-integration` (which
+> imports them), so a standalone PyPI release of the whole stack is non-trivial.
 
 This plan turns roadmap item **Publish** into a repeatable release process for
 `PythonSpinDynamics`: beta versioning, PyPI/TestPyPI publication, MkDocs-hosted

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,0 +1,81 @@
+# Release Process
+
+_Last updated: 2026-06-28_
+
+MRSpinDynamics is released as a **single citable unit**: the whole repository is
+versioned together, tagged once, published as one GitHub Release, and archived on
+Zenodo to mint a citable DOI. There is no per-subproject PyPI publishing — the
+subprojects are interdependent and at very different maturity levels, so a single
+workspace version is the model that fits.
+
+> If independent PyPI distribution of a specific subproject (most likely
+> `PythonSpinDynamics`) is wanted later, see
+> [`publishing_plan.md`](publishing_plan.md). That is a possible **future**
+> direction, not the current release model.
+
+## Versioning
+
+- One version of record for the whole workspace, stored in
+  [`CITATION.cff`](../CITATION.cff) (`version:`) and the top
+  [`CHANGELOG.md`](../CHANGELOG.md).
+- Subproject `pyproject.toml` files carry the same version for internal
+  consistency, but they are not published independently.
+- A subproject's `Development Status` classifier still reflects its own maturity
+  (e.g. `PythonSpinDynamics` is more mature than `QuadrupolarDFT`); the shared
+  version number is not a uniform stability claim.
+- Tags use a plain `v<version>` form, e.g. `v0.1.0`.
+
+## One-time setup (maintainer)
+
+Citation and DOI minting need accounts and cannot be scripted in this repo:
+
+1. Sign in to [Zenodo](https://zenodo.org/) with the GitHub account that owns the
+   repository.
+2. Under **Zenodo -> GitHub**, toggle the `supertjhok/MRSpinDynamics` repository
+   **On**. Zenodo then archives every subsequent GitHub Release and mints a DOI.
+3. (Optional) Confirm the GitHub "Cite this repository" button renders from
+   [`CITATION.cff`](../CITATION.cff).
+
+Zenodo issues a *concept DOI* (always resolves to the latest version) plus a
+*version DOI* per release. After the first release, add the concept DOI to
+[`CITATION.cff`](../CITATION.cff) (`doi:`) and a badge to the README.
+
+## Cutting a release
+
+1. Confirm CI is green on `main` (PythonSpinDynamics, QuadrupolarDFT,
+   NQRDatabase, and integration workflows).
+2. Bump the version everywhere it appears:
+   - [`CITATION.cff`](../CITATION.cff) `version:` and `date-released:`
+   - [`.zenodo.json`](../.zenodo.json) (no version field; review metadata)
+   - `PythonSpinDynamics/pyproject.toml`, `QuadrupolarDFT/pyproject.toml`,
+     `integration/pyproject.toml`
+   - the `scripts/bump_version.py` helper does this in one step (see below).
+3. Move the `Unreleased` section of [`CHANGELOG.md`](../CHANGELOG.md) to the new
+   version with today's date, and add a fresh `Unreleased` header.
+4. Regenerate any committed generated artifacts and confirm no drift, e.g.:
+
+   ```powershell
+   cd PythonSpinDynamics
+   python docs\generate_api_reference.py
+   git diff --exit-code docs\python_api\api_reference.md
+   ```
+
+5. Commit the version bump and changelog.
+6. Tag and push:
+
+   ```powershell
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+7. The [release workflow](../.github/workflows/release.yml) creates a GitHub
+   Release from the tag using the changelog section as the body. (Or create the
+   Release manually with `gh release create v0.1.0 --notes-file <section>`.)
+8. Zenodo archives the Release and mints the DOI. Add the DOI to
+   [`CITATION.cff`](../CITATION.cff) and the README badge in a follow-up commit.
+
+## Consistency check
+
+`scripts/check_versions.py` fails if the versions in `CITATION.cff` and the three
+`pyproject.toml` files disagree. It runs in CI so a release can never ship with a
+split version.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -155,8 +155,12 @@ AIMD/PIMD averaging for anharmonic cases like NaNO₂ near Tc.
    data, convergence checks, and clearer limits of validity.
 4. **JAX/Numba isochromat backend** — unlocks speed *and* autodiff pulse
    optimization. Highest engineering payoff.
-5. **Publish.** Version bump → PyPI → MkDocs site → JOSS. Detailed plan:
-   `docs/publishing_plan.md`.
+5. **Publish.** Release the workspace as a single citable unit: one repo version,
+   one GitHub Release, one Zenodo DOI. Process: `docs/release_process.md`
+   (scaffolding — `CITATION.cff`, `.zenodo.json`, `CHANGELOG.md`, version-sync
+   scripts, and the release workflow — is in place; remaining is the one-time
+   Zenodo↔GitHub hookup and tagging `v0.1.0`). Independent PyPI publication of a
+   subpackage is a deferred future option (`docs/publishing_plan.md`).
 6. **Database enrichment from DFT** — a "predicted vs measured" column in the
    NQR explorer UI. Visually striking, directly useful.
 7. **Repo hygiene** — ABINIT binaries are now gitignored (done); remaining:

--- a/integration/pyproject.toml
+++ b/integration/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mr-integration"
-version = "0.0.0"
+version = "0.1.0"
 description = "Cross-project bridge: ab initio EFG, spin-dynamics simulation, and the measured NQR database."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Set the workspace version across all release artifacts in one step.
+
+Updates the ``version:`` field in ``CITATION.cff`` and the ``version`` field in
+each subproject ``pyproject.toml`` so they stay identical (see
+``docs/release_process.md``). Does not touch the CHANGELOG or create a tag.
+
+Usage:
+    python scripts/bump_version.py 0.2.0
+    python scripts/bump_version.py 0.2.0 --date 2026-09-01   # also set CITATION date-released
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CITATION = REPO_ROOT / "CITATION.cff"
+PYPROJECTS = [
+    REPO_ROOT / "PythonSpinDynamics" / "pyproject.toml",
+    REPO_ROOT / "QuadrupolarDFT" / "pyproject.toml",
+    REPO_ROOT / "integration" / "pyproject.toml",
+]
+
+# A loose semver-ish check; allows pre-release suffixes like 0.2.0rc1.
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+([abrc].*)?$")
+
+
+def _sub_once(text: str, pattern: str, replacement: str, path: Path) -> str:
+    new_text, count = re.subn(pattern, replacement, text, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise ValueError(f"could not update pattern {pattern!r} in {path}")
+    return new_text
+
+
+def bump_citation(path: Path, version: str, date: str | None) -> None:
+    text = path.read_text(encoding="utf-8")
+    text = _sub_once(text, r'^version:.*$', f'version: {version}', path)
+    if date is not None:
+        text = _sub_once(text, r'^date-released:.*$', f'date-released: {date}', path)
+    path.write_text(text, encoding="utf-8")
+
+
+def bump_pyproject(path: Path, version: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    text = _sub_once(text, r'^version\s*=\s*".*"$', f'version = "{version}"', path)
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="new workspace version, e.g. 0.2.0")
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="optional date-released for CITATION.cff (YYYY-MM-DD)",
+    )
+    args = parser.parse_args()
+
+    if not VERSION_RE.match(args.version):
+        print(f"error: {args.version!r} is not a valid version", file=sys.stderr)
+        return 2
+
+    try:
+        bump_citation(CITATION, args.version, args.date)
+        for path in PYPROJECTS:
+            bump_pyproject(path, args.version)
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Set workspace version to {args.version}.")
+    print("Next: update CHANGELOG.md, commit, then tag v" + args.version + ".")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Fail if the workspace version is not identical across all release artifacts.
+
+MRSpinDynamics ships as a single citable unit (see ``docs/release_process.md``),
+so ``CITATION.cff`` and every subproject ``pyproject.toml`` must declare the same
+version. This check runs in CI so a release can never go out with a split
+version.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CITATION = REPO_ROOT / "CITATION.cff"
+PYPROJECTS = [
+    REPO_ROOT / "PythonSpinDynamics" / "pyproject.toml",
+    REPO_ROOT / "QuadrupolarDFT" / "pyproject.toml",
+    REPO_ROOT / "integration" / "pyproject.toml",
+]
+
+
+def citation_version(path: Path) -> str:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"""^version:\s*["']?([^"'#\s]+)""", line)
+        if match:
+            return match.group(1)
+    raise ValueError(f"no 'version:' field found in {path}")
+
+
+def pyproject_version(path: Path) -> str:
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    return data["project"]["version"]
+
+
+def main() -> int:
+    versions: dict[str, str] = {}
+    try:
+        versions[str(CITATION.relative_to(REPO_ROOT))] = citation_version(CITATION)
+        for path in PYPROJECTS:
+            versions[str(path.relative_to(REPO_ROOT))] = pyproject_version(path)
+    except (OSError, KeyError, ValueError) as exc:
+        print(f"error reading versions: {exc}", file=sys.stderr)
+        return 2
+
+    distinct = set(versions.values())
+    width = max(len(name) for name in versions)
+    for name, version in versions.items():
+        print(f"  {name:<{width}}  {version}")
+
+    if len(distinct) != 1:
+        print(
+            f"\nFAIL: versions disagree: {sorted(distinct)}\n"
+            "Use scripts/bump_version.py <version> to set them together.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nOK: workspace version is {distinct.pop()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/extract_changelog.py
+++ b/scripts/extract_changelog.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Print the CHANGELOG.md section for one version, for use as release notes.
+
+Usage:
+    python scripts/extract_changelog.py 0.1.0
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+CHANGELOG = Path(__file__).resolve().parent.parent / "CHANGELOG.md"
+
+
+def extract(version: str) -> str:
+    lines = CHANGELOG.read_text(encoding="utf-8").splitlines()
+    # Match "## [0.1.0]" optionally followed by " - date".
+    header = re.compile(rf"^##\s+\[{re.escape(version)}\]")
+    next_header = re.compile(r"^##\s+\[")
+    out: list[str] = []
+    capturing = False
+    for line in lines:
+        if header.match(line):
+            capturing = True
+            continue
+        if capturing and next_header.match(line):
+            break
+        if capturing:
+            out.append(line)
+    body = "\n".join(out).strip()
+    if not body:
+        raise SystemExit(f"no changelog section found for version {version!r}")
+    return body
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: extract_changelog.py <version>")
+    print(extract(sys.argv[1]))


### PR DESCRIPTION
Add unified workspace release scaffolding (v0.1.0)

Release the whole repository as a single citable unit rather than publishing each subproject independently. The subprojects are interdependent and at very different maturity, so one workspace version
- one git tag, one GitHub Release, one Zenodo DOI - is the model that fits.

- CITATION.cff (validated against CFF 1.2.0) and .zenodo.json so the repo is citable and GitHub shows a "Cite this repository" button
- Top-level CHANGELOG.md with per-subproject 0.1.0 notes; doubles as the GitHub Release body
- docs/release_process.md documents the single-version flow and the one-time Zenodo<->GitHub hookup; publishing_plan.md (per-package PyPI) reframed as a deferred future option; roadmap "Publish" item updated
- scripts/: check_versions.py (CI gate), bump_version.py, and extract_changelog.py keep one version across CITATION.cff and the three pyproject.toml files
- Sync all component versions 0.0.0 -> 0.1.0
- Workflows: release.yml (tag v* -> GitHub Release from changelog, which Zenodo archives) and workspace.yml (version-consistency gate)
- gitignore build/, dist/, site/ artifacts

Verified: check_versions OK at 0.1.0, extract_changelog returns the 0.1.0 section, CITATION.cff valid (cffconvert), .zenodo.json valid JSON.


@